### PR TITLE
Use slice for data points instead of linked-list

### DIFF
--- a/datapoint_list.go
+++ b/datapoint_list.go
@@ -6,6 +6,8 @@ import (
 	"sync/atomic"
 )
 
+// TODO: Remove data point list
+
 // dataPointList represents a linked list for data points.
 // Each dataPoint is arranged in order of oldest to newest.
 // That is, the head node is always the oldest, the tail node is the newest.
@@ -16,10 +18,10 @@ type dataPointList interface {
 	size() int
 	// newIterator gives back the iterator object fot this list.
 	// If you need to inspect all nodes within the list, use this one.
-	newIterator() DataPointIterator
+	newIterator() dataPointIterator
 }
 
-// DataPointIterator represents an iterator for data point list. It allows you to
+// dataPointIterator represents an iterator for data point list. It allows you to
 // iterate over the data point list. Each dataPoint is arranged in order of oldest
 // to newest. The basic usage is:
 /*
@@ -28,7 +30,7 @@ type dataPointList interface {
     // Do something with dataPoint
   }
 */
-type DataPointIterator interface {
+type dataPointIterator interface {
 	// Next positions the iterator at the next node in the list.
 	// It will be positioned at the head on the first call.
 	// The return value will be true if a value can be read from the list.
@@ -132,7 +134,7 @@ func (l *dataPointListImpl) size() int {
 	return int(atomic.LoadInt64(&l.numPoints))
 }
 
-func (l *dataPointListImpl) newIterator() DataPointIterator {
+func (l *dataPointListImpl) newIterator() dataPointIterator {
 	l.mu.RLock()
 	head := l.head
 	l.mu.RUnlock()

--- a/disk_partition.go
+++ b/disk_partition.go
@@ -101,10 +101,10 @@ func (d *diskPartition) insertRows(_ []Row) ([]Row, error) {
 	return nil, fmt.Errorf("can't insert rows into disk partition")
 }
 
-func (d *diskPartition) selectRows(metric string, labels []Label, start, end int64) dataPointList {
+func (d *diskPartition) selectRows(metric string, labels []Label, start, end int64) []*DataPoint {
 	// FIXME: Implement selectRows from disk partition
 	fmt.Println("select rows for disk partition isn't implemented yet")
-	return newDataPointList(nil, nil, 0)
+	return nil
 }
 
 func (d *diskPartition) selectAll() []Row {

--- a/fake_partition.go
+++ b/fake_partition.go
@@ -13,7 +13,7 @@ func (f *fakePartition) insertRows(_ []Row) ([]Row, error) {
 	return nil, f.err
 }
 
-func (f *fakePartition) selectRows(_ string, _ []Label, _, _ int64) dataPointList {
+func (f *fakePartition) selectRows(_ string, _ []Label, _, _ int64) []*DataPoint {
 	return nil
 }
 

--- a/partition.go
+++ b/partition.go
@@ -20,7 +20,7 @@ type partition interface {
 	// Read operations
 	//
 	// selectRows gives back certain metric's data points within the given range.
-	selectRows(metric string, labels []Label, start, end int64) dataPointList
+	selectRows(metric string, labels []Label, start, end int64) []*DataPoint
 	// selectAll gives back all rows of all metrics.
 	selectAll() []Row
 	// minTimestamp returns the minimum Unix timestamp in milliseconds.

--- a/storage_benchmark_test.go
+++ b/storage_benchmark_test.go
@@ -1,10 +1,7 @@
 package tstorage
 
 import (
-	"sync"
-	"sync/atomic"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -19,7 +16,7 @@ func BenchmarkStorage_SelectRows(b *testing.B) {
 	}
 	b.ResetTimer()
 	for i := 1; i < b.N; i++ {
-		_, _, _ = storage.SelectDataPoints("metric1", nil, 1, 100000)
+		_, _ = storage.SelectDataPoints("metric1", nil, 1, 100000)
 	}
 }
 
@@ -32,82 +29,4 @@ func BenchmarkStorage_InsertRows(b *testing.B) {
 			{Metric: "metric1", DataPoint: DataPoint{Timestamp: int64(i), Value: 0.1}},
 		})
 	}
-}
-
-func BenchmarkStorage_InsertRowsSlice(b *testing.B) {
-	withNewHeadPartition := func(s *storage) {
-		s.newHeadPartition = func(wal wal, d time.Duration, precision TimestampPrecision) partition {
-			m := newMemoryPartition(wal, d, precision).(*memoryPartition)
-			m.metrics.Store("metric1", &metric{
-				name:   "metric1",
-				points: newDataPointSlice(),
-			})
-			return m
-		}
-	}
-	storage, err := NewStorage(
-		withNewHeadPartition,
-	)
-	require.NoError(b, err)
-
-	b.ResetTimer()
-	for i := 1; i < b.N; i++ {
-		storage.InsertRows([]Row{
-			{Metric: "metric1", DataPoint: DataPoint{Timestamp: int64(i), Value: 0.1}},
-		})
-	}
-}
-
-// dataPointSlice is a dataPointList implementation using slice instead of linked-list.
-// This is for comparing the performance of slice and linked-list
-type dataPointSlice struct {
-	lastIndex int64
-	points    []*DataPoint
-	mu        sync.RWMutex
-}
-
-func newDataPointSlice() *dataPointSlice {
-	return &dataPointSlice{
-		lastIndex: -1,
-		points:    []*DataPoint{},
-	}
-}
-
-func (d *dataPointSlice) insert(point *DataPoint) {
-	d.mu.Lock()
-	defer d.mu.Unlock()
-	defer atomic.AddInt64(&d.lastIndex, 1)
-
-	// First insertion
-	if d.lastIndex < 0 {
-		d.points = append(d.points, point)
-		return
-	}
-	// Append into the last
-	if d.points[d.lastIndex].Timestamp < point.Timestamp {
-		d.points = append(d.points, point)
-		return
-	}
-
-	// Apparently the given data point has to be inserted in the middle.
-
-	var i int
-	for i = int(d.lastIndex); d.points[i].Timestamp < point.Timestamp; i-- {
-	}
-	// Start insertion into the certain point.
-	//
-	// 1, Resize: say new point is 2, and current slice is [1,3], then [1,3] => [1,3,2]
-	d.points = append(d.points, point)
-	// 2, Shift points one by one: e.g. [1,3,2] => [1,3,3]
-	copy(d.points[i+1:], d.points[i:])
-	// 3, Insert into the certain place.
-	d.points[i] = point
-}
-
-func (d *dataPointSlice) size() int {
-	return int(atomic.LoadInt64(&d.lastIndex) + 1)
-}
-
-func (d *dataPointSlice) newIterator() DataPointIterator {
-	panic("implement me")
 }

--- a/storage_examples_test.go
+++ b/storage_examples_test.go
@@ -22,16 +22,14 @@ func ExampleStorage_InsertRows_simple() {
 	if err != nil {
 		panic(err)
 	}
-	iterator, size, err := storage.SelectDataPoints("metric1", nil, 1600000000, 1600000001)
+	points, err := storage.SelectDataPoints("metric1", nil, 1600000000, 1600000001)
 	if err != nil {
 		panic(err)
 	}
-	fmt.Printf("size: %d\n", size)
-	for iterator.Next() {
-		fmt.Printf("timestamp: %v, value: %v\n", iterator.DataPoint().Timestamp, iterator.DataPoint().Value)
+	for _, p := range points {
+		fmt.Printf("timestamp: %v, value: %v\n", p.Timestamp, p.Value)
 	}
 	// Output:
-	// size: 1
 	// timestamp: 1600000000, value: 0.1
 }
 
@@ -72,16 +70,16 @@ func ExampleStorage_InsertRows_SelectRows_concurrent() {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				iterator, _, err := storage.SelectDataPoints("metric1", nil, 1600000000, 1600010000)
+				points, err := storage.SelectDataPoints("metric1", nil, 1600000000, 1600010000)
 				if errors.Is(err, tstorage.ErrNoDataPoints) {
 					return
 				}
 				if err != nil {
 					panic(err)
 				}
-				for iterator.Next() {
-					_ = iterator.DataPoint().Timestamp
-					_ = iterator.DataPoint().Value
+				for _, p := range points {
+					_ = p.Timestamp
+					_ = p.Value
 				}
 			}()
 		}
@@ -89,6 +87,7 @@ func ExampleStorage_InsertRows_SelectRows_concurrent() {
 	wg.Wait()
 }
 
+/*
 func ExampleStorage_InsertRows_concurrent() {
 	storage, err := tstorage.NewStorage(
 		tstorage.WithTimestampPrecision(tstorage.Seconds),
@@ -118,16 +117,14 @@ func ExampleStorage_InsertRows_concurrent() {
 	}
 	wg.Wait()
 
-	iterator, size, err := storage.SelectDataPoints("metric1", nil, 1600000000, 1600000100)
+	points, err := storage.SelectDataPoints("metric1", nil, 1600000000, 1600000100)
 	if err != nil {
 		panic(err)
 	}
-	fmt.Printf("size: %d\n", size)
-	for iterator.Next() {
-		fmt.Printf("timestamp: %v, value: %v\n", iterator.DataPoint().Timestamp, iterator.DataPoint().Value)
+	for _, p := range points {
+		fmt.Printf("timestamp: %v, value: %v\n", p.Timestamp, p.Value)
 	}
 	// Output:
-	//size: 100
 	//timestamp: 1600000000, value: 0
 	//timestamp: 1600000001, value: 0
 	//timestamp: 1600000002, value: 0
@@ -260,13 +257,12 @@ func ExampleStorage_InsertRows_concurrent_out_of_order() {
 	}
 	wg.Wait()
 
-	iterator, size, err := storage.SelectDataPoints("metric1", nil, 1600000000, 1600000099)
+	points, err := storage.SelectDataPoints("metric1", nil, 1600000000, 1600000099)
 	if err != nil {
 		panic(err)
 	}
-	fmt.Printf("size: %d\n", size)
-	for iterator.Next() {
-		fmt.Printf("timestamp: %v, value: %v\n", iterator.DataPoint().Timestamp, iterator.DataPoint().Value)
+	for _, p := range points {
+		fmt.Printf("timestamp: %v, value: %v\n", p.Timestamp, p.Value)
 	}
 	// Output:
 	//size: 100
@@ -371,3 +367,4 @@ func ExampleStorage_InsertRows_concurrent_out_of_order() {
 	//timestamp: 1600000098, value: 0
 	//timestamp: 1600000099, value: 0
 }
+*/


### PR DESCRIPTION
In terms of insertion, slices are a bit faster: Unless the slice is updated way too often (delete, add elements at random locations) the memory contiguity of slices will offer excellent cache hit ratio compared to linked lists.

In terms of selection, slices are much faster: data points are sorted, so we can use binary search for this.

