### PR TITLE
Merge out of order data points before flushing to disk

### DIFF
--- a/fake_encoder.go
+++ b/fake_encoder.go
@@ -1,0 +1,14 @@
+package tstorage
+
+type fakeEncoder struct {
+	encodePointFunc func(*DataPoint) error
+	flushFunc       func() error
+}
+
+func (f *fakeEncoder) encodePoint(p *DataPoint) error {
+	return f.encodePointFunc(p)
+}
+
+func (f *fakeEncoder) flush() error {
+	return f.flushFunc()
+}

--- a/memory_partition.go
+++ b/memory_partition.go
@@ -233,7 +233,7 @@ func (m *memoryMetric) selectPoints(start, end int64) []*DataPoint {
 }
 
 // encodeAllPoints uses the given seriesEncoder to encode all metric data points in order by timestamp,
-// including outOfOrderPoints. Returns immediately on any encoding errors.
+// including outOfOrderPoints.
 func (m *memoryMetric) encodeAllPoints(encoder seriesEncoder) error {
 	sort.Slice(m.outOfOrderPoints, func(i, j int) bool {
 		return m.outOfOrderPoints[i].Timestamp < m.outOfOrderPoints[j].Timestamp

--- a/memory_partition.go
+++ b/memory_partition.go
@@ -232,6 +232,8 @@ func (m *memoryMetric) selectPoints(start, end int64) []*DataPoint {
 	return m.points[startIdx:endIdx]
 }
 
+// encodeAllPoints uses the given seriesEncoder to encode all metric data points in order by timestamp,
+// including outOfOrderPoints. Returns immediately on any encoding errors.
 func (m *memoryMetric) encodeAllPoints(encoder seriesEncoder) error {
 	sort.Slice(m.outOfOrderPoints, func(i, j int) bool {
 		return m.outOfOrderPoints[i].Timestamp < m.outOfOrderPoints[j].Timestamp

--- a/memory_partition.go
+++ b/memory_partition.go
@@ -232,8 +232,8 @@ func (m *memoryMetric) selectPoints(start, end int64) []*DataPoint {
 	return m.points[startIdx:endIdx]
 }
 
-// iterateAllPoints iterates over all metric data points in order, including
-// out of order data points.
+// iterateAllPoints calls the given function f on all metric data points in order by timestamp,
+// including outOfOrderPoints. Returns immediately if f errors.
 func (m *memoryMetric) iterateAllPoints(f func(*DataPoint) error) error {
 	sort.Slice(m.outOfOrderPoints, func(i, j int) bool {
 		return m.outOfOrderPoints[i].Timestamp < m.outOfOrderPoints[j].Timestamp

--- a/memory_partition.go
+++ b/memory_partition.go
@@ -231,3 +231,40 @@ func (m *memoryMetric) selectPoints(start, end int64) []*DataPoint {
 	}
 	return m.points[startIdx:endIdx]
 }
+
+// iterateAllPoints iterates over all metric data points in order, including
+// out of order data points.
+func (m *memoryMetric) iterateAllPoints(f func(*DataPoint) error) error {
+	sort.Slice(m.outOfOrderPoints, func(i, j int) bool {
+		return m.outOfOrderPoints[i].Timestamp < m.outOfOrderPoints[j].Timestamp
+	})
+
+	var oi, pi int
+	for oi < len(m.outOfOrderPoints) && pi < len(m.points) {
+		if m.outOfOrderPoints[oi].Timestamp < m.points[pi].Timestamp {
+			if err := f(m.outOfOrderPoints[oi]); err != nil {
+				return err
+			}
+			oi++
+		} else {
+			if err := f(m.points[pi]); err != nil {
+				return err
+			}
+			pi++
+		}
+	}
+	for oi < len(m.outOfOrderPoints) {
+		if err := f(m.outOfOrderPoints[oi]); err != nil {
+			return err
+		}
+		oi++
+	}
+	for pi < len(m.points) {
+		if err := f(m.points[pi]); err != nil {
+			return err
+		}
+		pi++
+	}
+
+	return nil
+}

--- a/memory_partition_test.go
+++ b/memory_partition_test.go
@@ -146,10 +146,11 @@ func Test_memoryMetric_EncodeAllPoints_sorted(t *testing.T) {
 			{Timestamp: 3, Value: 0.1},
 		},
 		outOfOrderPoints: []*DataPoint{
+			{Timestamp: 4, Value: 0.1},
 			{Timestamp: 2, Value: 0.1},
 		},
 	}
-	allTimestamps := make([]int64, 0, 3)
+	allTimestamps := make([]int64, 0, 4)
 	encoder := fakeEncoder{
 		encodePointFunc: func(p *DataPoint) error {
 			allTimestamps = append(allTimestamps, p.Timestamp)
@@ -158,7 +159,7 @@ func Test_memoryMetric_EncodeAllPoints_sorted(t *testing.T) {
 	}
 	err := mt.encodeAllPoints(&encoder)
 	require.NoError(t, err)
-	assert.Equal(t, []int64{1, 2, 3}, allTimestamps)
+	assert.Equal(t, []int64{1, 2, 3, 4}, allTimestamps)
 }
 
 func Test_memoryMetric_IterateAllPoints_error(t *testing.T) {

--- a/memory_partition_test.go
+++ b/memory_partition_test.go
@@ -1,10 +1,12 @@
 package tstorage
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_memoryPartition_InsertRows(t *testing.T) {
@@ -135,6 +137,35 @@ func Test_memoryPartition_SelectDataPoints(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func Test_memoryMetric_IterateAllPoints_sorted(t *testing.T) {
+	mt := memoryMetric{
+		points: []*DataPoint{
+			{Timestamp: 1, Value: 0.1},
+			{Timestamp: 3, Value: 0.1},
+		},
+		outOfOrderPoints: []*DataPoint{
+			{Timestamp: 2, Value: 0.1},
+		},
+	}
+	allTimestamps := make([]int64, 0, 3)
+	err := mt.iterateAllPoints(func(p *DataPoint) error {
+		allTimestamps = append(allTimestamps, p.Timestamp)
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []int64{1, 2, 3}, allTimestamps)
+}
+
+func Test_memoryMetric_IterateAllPoints_error(t *testing.T) {
+	mt := memoryMetric{
+		points: []*DataPoint{{Timestamp: 1, Value: 0.1}},
+	}
+	err := mt.iterateAllPoints(func(p *DataPoint) error {
+		return fmt.Errorf("some error")
+	})
+	assert.Error(t, err)
 }
 
 func Test_toUnix(t *testing.T) {

--- a/memory_partition_test.go
+++ b/memory_partition_test.go
@@ -162,7 +162,7 @@ func Test_memoryMetric_EncodeAllPoints_sorted(t *testing.T) {
 	assert.Equal(t, []int64{1, 2, 3, 4}, allTimestamps)
 }
 
-func Test_memoryMetric_IterateAllPoints_error(t *testing.T) {
+func Test_memoryMetric_EncodeAllPoints_error(t *testing.T) {
 	mt := memoryMetric{
 		points: []*DataPoint{{Timestamp: 1, Value: 0.1}},
 	}

--- a/storage.go
+++ b/storage.go
@@ -468,6 +468,7 @@ func (s *storage) flush(dirPath string, m *memoryPartition) error {
 			}
 			pi++
 		}
+		totalNumPoints := mt.size + int64(len(mt.outOfOrderPoints))
 		// for _, p := range mt.points {
 		// 	if err := encoder.encodePoint(p); err != nil {
 		// 		s.logger.Printf("failed to encode a data point that metric is %q: %v\n", mt.name, err)
@@ -483,7 +484,7 @@ func (s *storage) flush(dirPath string, m *memoryPartition) error {
 			Offset:        offset,
 			MinTimestamp:  mt.minTimestamp,
 			MaxTimestamp:  mt.maxTimestamp,
-			NumDataPoints: mt.size,
+			NumDataPoints: totalNumPoints,
 		}
 		return true
 	})

--- a/storage.go
+++ b/storage.go
@@ -435,8 +435,7 @@ func (s *storage) flush(dirPath string, m *memoryPartition) error {
 			return false
 		}
 
-		err = mt.iterateAllPoints(encoder.encodePoint)
-		if err != nil {
+		if err := mt.iterateAllPoints(encoder.encodePoint); err != nil {
 			s.logger.Printf("failed to encode a data point that metric is %q: %v\n", mt.name, err)
 			return false
 		}

--- a/storage.go
+++ b/storage.go
@@ -435,7 +435,7 @@ func (s *storage) flush(dirPath string, m *memoryPartition) error {
 			return false
 		}
 
-		if err := mt.iterateAllPoints(encoder.encodePoint); err != nil {
+		if err := mt.encodeAllPoints(encoder); err != nil {
 			s.logger.Printf("failed to encode a data point that metric is %q: %v\n", mt.name, err)
 			return false
 		}

--- a/storage.go
+++ b/storage.go
@@ -299,7 +299,7 @@ func (s *storage) Select(metric string, labels []Label, start, end int64) ([]*Da
 		return nil, fmt.Errorf("metric must be set")
 	}
 	if start >= end {
-		return nil, fmt.Errorf("thg given start is greater than end")
+		return nil, fmt.Errorf("the given start is greater than end")
 	}
 	points := make([]*DataPoint, 0)
 

--- a/storage_examples_test.go
+++ b/storage_examples_test.go
@@ -469,7 +469,8 @@ func ExampleStorage_Select_from_disk() {
 	//Timestamp: 1600000049, Value: 0.2
 }
 
-func ExampleStorage_InsertRows_out_of_order() {
+// Out of order data points not yet flushed are buffered but do not appear in select.
+func ExampleStorage_Select_out_of_order() {
 	storage, err := tstorage.NewStorage(
 		tstorage.WithTimestampPrecision(tstorage.Seconds),
 	)
@@ -499,11 +500,11 @@ func ExampleStorage_InsertRows_out_of_order() {
 	}
 	// Output:
 	// timestamp: 1600000000, value: 0.1
-	// timestamp: 1600000001, value: 0.1
 	// timestamp: 1600000002, value: 0.1
 	// timestamp: 1600000003, value: 0.1
 }
 
+// Out of order data points that are flushed should appear in select.
 func ExampleStorage_Select_from_disk_out_of_order() {
 	tmpDir, err := ioutil.TempDir("", "tstorage-example")
 	if err != nil {

--- a/storage_examples_test.go
+++ b/storage_examples_test.go
@@ -469,7 +469,8 @@ func ExampleStorage_Select_from_disk() {
 	//Timestamp: 1600000049, Value: 0.2
 }
 
-// Out of order data points not yet flushed are buffered but do not appear in select.
+// Out of order data points that are not yet flushed are in the buffer
+// but do not appear in select.
 func ExampleStorage_Select_out_of_order() {
 	storage, err := tstorage.NewStorage(
 		tstorage.WithTimestampPrecision(tstorage.Seconds),

--- a/storage_examples_test.go
+++ b/storage_examples_test.go
@@ -551,7 +551,7 @@ func ExampleStorage_Select_from_disk_out_of_order() {
 		}
 	}()
 
-	points, err := storage.Select("metric1", nil, 1600000000, 1600000007)
+	points, err := storage.Select("metric1", nil, 1600000000, 1600000004)
 	if errors.Is(err, tstorage.ErrNoDataPoints) {
 		return
 	}

--- a/storage_examples_test.go
+++ b/storage_examples_test.go
@@ -62,39 +62,6 @@ func ExampleStorage_InsertRows() {
 	// timestamp: 1600000000, value: 0.1
 }
 
-func ExampleStorage_InsertRows_out_of_order() {
-	storage, err := tstorage.NewStorage(
-		tstorage.WithTimestampPrecision(tstorage.Seconds),
-	)
-	if err != nil {
-		panic(err)
-	}
-	defer func() {
-		if err := storage.Close(); err != nil {
-			panic(err)
-		}
-	}()
-	err = storage.InsertRows([]tstorage.Row{
-		{Metric: "metric1", DataPoint: tstorage.DataPoint{Timestamp: 1600000000, Value: 0.1}},
-		{Metric: "metric1", DataPoint: tstorage.DataPoint{Timestamp: 1600000002, Value: 0.1}},
-		{Metric: "metric1", DataPoint: tstorage.DataPoint{Timestamp: 1600000001, Value: 0.1}},
-	})
-	if err != nil {
-		panic(err)
-	}
-	points, err := storage.Select("metric1", nil, 1600000000, 1600000002)
-	if err != nil {
-		panic(err)
-	}
-	for _, p := range points {
-		fmt.Printf("timestamp: %v, value: %v\n", p.Timestamp, p.Value)
-	}
-	// Output:
-	// timestamp: 1600000000, value: 0.1
-	// timestamp: 1600000001, value: 0.1
-	// timestamp: 1600000002, value: 0.1
-}
-
 // simulates writing and reading in concurrent.
 func ExampleStorage_InsertRows_Select_concurrent() {
 	storage, err := tstorage.NewStorage(
@@ -500,6 +467,104 @@ func ExampleStorage_Select_from_disk() {
 	//Timestamp: 1600000047, Value: 0.2
 	//Timestamp: 1600000048, Value: 0.2
 	//Timestamp: 1600000049, Value: 0.2
+}
+
+func ExampleStorage_InsertRows_out_of_order() {
+	storage, err := tstorage.NewStorage(
+		tstorage.WithTimestampPrecision(tstorage.Seconds),
+	)
+	if err != nil {
+		panic(err)
+	}
+	defer func() {
+		if err := storage.Close(); err != nil {
+			panic(err)
+		}
+	}()
+	err = storage.InsertRows([]tstorage.Row{
+		{Metric: "metric1", DataPoint: tstorage.DataPoint{Timestamp: 1600000000, Value: 0.1}},
+		{Metric: "metric1", DataPoint: tstorage.DataPoint{Timestamp: 1600000002, Value: 0.1}},
+		{Metric: "metric1", DataPoint: tstorage.DataPoint{Timestamp: 1600000001, Value: 0.1}},
+		{Metric: "metric1", DataPoint: tstorage.DataPoint{Timestamp: 1600000003, Value: 0.1}},
+	})
+	if err != nil {
+		panic(err)
+	}
+	points, err := storage.Select("metric1", nil, 1600000000, 1600000003)
+	if err != nil {
+		panic(err)
+	}
+	for _, p := range points {
+		fmt.Printf("timestamp: %v, value: %v\n", p.Timestamp, p.Value)
+	}
+	// Output:
+	// timestamp: 1600000000, value: 0.1
+	// timestamp: 1600000001, value: 0.1
+	// timestamp: 1600000002, value: 0.1
+	// timestamp: 1600000003, value: 0.1
+}
+
+func ExampleStorage_Select_from_disk_out_of_order() {
+	tmpDir, err := ioutil.TempDir("", "tstorage-example")
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	storage, err := tstorage.NewStorage(
+		tstorage.WithDataPath(tmpDir),
+		tstorage.WithPartitionDuration(100*time.Second),
+		tstorage.WithTimestampPrecision(tstorage.Seconds),
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	err = storage.InsertRows([]tstorage.Row{
+		{Metric: "metric1", DataPoint: tstorage.DataPoint{Timestamp: 1600000000, Value: 0.1}},
+		{Metric: "metric1", DataPoint: tstorage.DataPoint{Timestamp: 1600000002, Value: 0.1}},
+		{Metric: "metric1", DataPoint: tstorage.DataPoint{Timestamp: 1600000001, Value: 0.1}},
+		{Metric: "metric1", DataPoint: tstorage.DataPoint{Timestamp: 1600000003, Value: 0.1}},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	// Flush all data points
+	if err := storage.Close(); err != nil {
+		panic(err)
+	}
+
+	// Re-open storage from the persisted data
+	storage, err = tstorage.NewStorage(
+		tstorage.WithDataPath(tmpDir),
+		tstorage.WithPartitionDuration(100*time.Second),
+		tstorage.WithTimestampPrecision(tstorage.Seconds),
+	)
+	if err != nil {
+		panic(err)
+	}
+	defer func() {
+		if err := storage.Close(); err != nil {
+			panic(err)
+		}
+	}()
+
+	points, err := storage.Select("metric1", nil, 1600000000, 1600000007)
+	if errors.Is(err, tstorage.ErrNoDataPoints) {
+		return
+	}
+	if err != nil {
+		panic(err)
+	}
+	for _, p := range points {
+		fmt.Printf("timestamp: %v, value: %v\n", p.Timestamp, p.Value)
+	}
+	// Output:
+	// timestamp: 1600000000, value: 0.1
+	// timestamp: 1600000001, value: 0.1
+	// timestamp: 1600000002, value: 0.1
+	// timestamp: 1600000003, value: 0.1
 }
 
 func ExampleStorage_InsertRows_concurrent() {

--- a/storage_examples_test.go
+++ b/storage_examples_test.go
@@ -471,7 +471,7 @@ func ExampleStorage_Select_from_disk() {
 
 // Out of order data points that are not yet flushed are in the buffer
 // but do not appear in select.
-func ExampleStorage_Select_out_of_order() {
+func ExampleStorage_Select_from_memory_out_of_order() {
 	storage, err := tstorage.NewStorage(
 		tstorage.WithTimestampPrecision(tstorage.Seconds),
 	)
@@ -497,12 +497,15 @@ func ExampleStorage_Select_out_of_order() {
 		panic(err)
 	}
 	for _, p := range points {
-		fmt.Printf("timestamp: %v, value: %v\n", p.Timestamp, p.Value)
+		fmt.Printf("Timestamp: %v, Value: %v\n", p.Timestamp, p.Value)
 	}
+
+	// Out-of-order data points are ignored because they will get merged when flushing.
+
 	// Output:
-	// timestamp: 1600000000, value: 0.1
-	// timestamp: 1600000002, value: 0.1
-	// timestamp: 1600000003, value: 0.1
+	// Timestamp: 1600000000, Value: 0.1
+	// Timestamp: 1600000002, Value: 0.1
+	// Timestamp: 1600000003, Value: 0.1
 }
 
 // Out of order data points that are flushed should appear in select.


### PR DESCRIPTION
This change sorts the out of order points and then merges the two slices before flushing buffered data to disk. This is a partial implementation of https://github.com/nakabonne/tstorage/issues/7 but doesn't handle points outside of the head partition bounds.