### PR TITLE
Support writes outside of head partition

### DIFF
--- a/storage.go
+++ b/storage.go
@@ -251,10 +251,10 @@ func (s *storage) InsertRows(rows []Row) error {
 		// of date are dropped.
 		for i := 0; i < defaultWritablePartitionsNum; i++ {
 			if len(rowsToInsert) == 0 {
-				return nil
+				break
 			}
 			if !iterator.next() {
-				return nil
+				break
 			}
 			outdatedRows, err := iterator.value().insertRows(rowsToInsert)
 			if err != nil {

--- a/storage.go
+++ b/storage.go
@@ -250,16 +250,17 @@ func (s *storage) InsertRows(rows []Row) error {
 		// into older partitions. Any rows more than `defaultWritablePartitionsNum` partitions out
 		// of date are dropped.
 		for i := 0; i < defaultWritablePartitionsNum; i++ {
-			if !iterator.next() {
-				return nil
-			}
-			rowsToInsert, err := iterator.value().insertRows(rowsToInsert)
-			if err != nil {
-				return fmt.Errorf("failed to insert rows: %w", err)
-			}
 			if len(rowsToInsert) == 0 {
 				return nil
 			}
+			if !iterator.next() {
+				return nil
+			}
+			outdatedRows, err := iterator.value().insertRows(rowsToInsert)
+			if err != nil {
+				return fmt.Errorf("failed to insert rows: %w", err)
+			}
+			rowsToInsert = outdatedRows
 		}
 		return nil
 	}

--- a/storage_examples_test.go
+++ b/storage_examples_test.go
@@ -588,11 +588,6 @@ func ExampleStorage_InsertRows_outdated() {
 	if err != nil {
 		panic(err)
 	}
-	defer func() {
-		if err := storage.Close(); err != nil {
-			panic(err)
-		}
-	}()
 
 	// Force two partitions with timestamps: (min: 1, max: 3), (min: 4, max: 5)
 	err = storage.InsertRows([]tstorage.Row{
@@ -670,11 +665,6 @@ func ExampleStorage_InsertRows_expired() {
 	if err != nil {
 		panic(err)
 	}
-	defer func() {
-		if err := storage.Close(); err != nil {
-			panic(err)
-		}
-	}()
 
 	// Force three partitions with timestamps: (min: 1, max: 3), (min: 4, max: 6), (min: 7, max: 8).
 	// Inserting the third partition will force the first one to be flushed to disk and become unwritable.


### PR DESCRIPTION
currently we only write to the head partition, this change supports writing to any of the writable partitions (currently set to 2).

ref https://github.com/nakabonne/tstorage/issues/20