### PR TITLE
Fix "slice bounds out of range" error in memoryMetric.selectPoints()

### DIFF
--- a/memory_partition.go
+++ b/memory_partition.go
@@ -236,8 +236,8 @@ func (m *memoryMetric) selectPoints(start, end int64) []*DataPoint {
 	} else {
 		// Use binary search because points are in-order.
 		endIdx = sort.Search(int(size), func(i int) bool {
-			return m.points[i].Timestamp < end
-		}) + 1
+			return m.points[i].Timestamp >= end
+		})
 	}
 	return m.points[startIdx:endIdx]
 }

--- a/memory_partition_test.go
+++ b/memory_partition_test.go
@@ -84,7 +84,43 @@ func Test_memoryPartition_SelectDataPoints(t *testing.T) {
 			want:            []*DataPoint{},
 		},
 		{
-			name:   "select multiple points",
+			name:   "select some points",
+			metric: "metric1",
+			start:  2,
+			end:    4,
+			memoryPartition: func() *memoryPartition {
+				m := newMemoryPartition(nil, 0, "").(*memoryPartition)
+				m.insertRows([]Row{
+					{
+						Metric:    "metric1",
+						DataPoint: DataPoint{Timestamp: 1, Value: 0.1},
+					},
+					{
+						Metric:    "metric1",
+						DataPoint: DataPoint{Timestamp: 2, Value: 0.1},
+					},
+					{
+						Metric:    "metric1",
+						DataPoint: DataPoint{Timestamp: 3, Value: 0.1},
+					},
+					{
+						Metric:    "metric1",
+						DataPoint: DataPoint{Timestamp: 4, Value: 0.1},
+					},
+					{
+						Metric:    "metric1",
+						DataPoint: DataPoint{Timestamp: 5, Value: 0.1},
+					},
+				})
+				return m
+			}(),
+			want: []*DataPoint{
+				{Timestamp: 2, Value: 0.1},
+				{Timestamp: 3, Value: 0.1},
+			},
+		},
+		{
+			name:   "select all points",
 			metric: "metric1",
 			start:  1,
 			end:    4,


### PR DESCRIPTION
This will fix a bug which I have encountered while using [nakabonne/ali](https://github.com/nakabonne/ali) (awesome! btw):

```text
panic: runtime error: slice bounds out of range [6:1]

goroutine 53 [running]:in:

github.com/nakabonne/tstorage.(*memoryMetric).selectPoints(0xc0001ba7e0, 0x16a06b537e57044c, 0x16a06b5a7a7ab04c, 0x0, 0x0, 0x0)
        /root/go/pkg/mod/github.com/nakabonne/tstorage@v0.2.0/memory_partition.go:232 +0x27b
github.com/nakabonne/tstorage.(*memoryPartition).selectDataPoints(0xc000132200, 0x82dbf7, 0x7, 0x0, 0x0, 0x0, 0x16a06b537e57044c, 0x16a06b5a7a7ab04c, 0x449a4c, 0xc000092238, ...)
        /root/go/pkg/mod/github.com/nakabonne/tstorage@v0.2.0/memory_partition.go:124 +0x9e
github.com/nakabonne/tstorage.(*storage).Select(0xc000132180, 0x82dbf7, 0x7, 0x0, 0x0, 0x0, 0x16a06b537e57044c, 0x16a06b5a7a7ab04c, 0x46a77b, 0x77b3455e6fa8, ...)
        /root/go/pkg/mod/github.com/nakabonne/tstorage@v0.2.0/storage.go:324 +0x262
github.com/nakabonne/ali/storage.(*storage).Select(0xc00012e260, 0x82dbf7, 0x7, 0xc043adf3db12ae4c, 0x323d8539, 0xb456e0, 0xc043adfb5b12ae4c, 0x72e613139, 0xb456e0, 0x0, ...)
        /opt/ali/storage/storage.go:116 +0x105
github.com/nakabonne/ali/gui.(*drawer).redrawCharts(0xc0001c6480, 0x8a5ab8, 0xc00007e000)
        /opt/ali/gui/drawer.go:53 +0x262
created by github.com/nakabonne/ali/gui.attack
        /opt/ali/gui/keybinds.go:55 +0x9d
```

In the original code almost always the first case (green) is entered - the bug occurs when the second (red) case is executed:

![image](https://user-images.githubusercontent.com/83718336/131555822-ef61c85a-53e0-42c9-9059-d9b60cdba165.png)
