### PR TITLE
Allow WAL segment to have invalid rows

### DIFF
--- a/disk_wal.go
+++ b/disk_wal.go
@@ -230,7 +230,7 @@ func (f *diskWALReader) readAll() error {
 		}
 
 		err = segment.error()
-		if errors.Is(err, io.ErrUnexpectedEOF) {
+		if errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, io.EOF) {
 			// It is not unusual for a line to be invalid, as it may well terminate in the middle of writing to the WAL.
 			return nil
 		}


### PR DESCRIPTION
If it crashes after tstorage has finished writing the timestamp, you may get an EOF error because the fixed size read is already complete.