### PR TITLE
GetRetention of the Tstorage instance added.

### DIFF
--- a/storage.go
+++ b/storage.go
@@ -359,6 +359,13 @@ func (s *storage) ensureActiveHead() error {
 	return nil
 }
 
+// GetRetention returns specified retention in duration It return default value unless specified.
+//
+// Defaults to 14d
+func (s *storage) GetRetention() time.Duration {
+	return s.retention
+}
+
 func (s *storage) Select(metric string, labels []Label, start, end int64) ([]*DataPoint, error) {
 	if metric == "" {
 		return nil, fmt.Errorf("metric must be set")

--- a/storage_test.go
+++ b/storage_test.go
@@ -109,5 +109,33 @@ func Test_storage_Select(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 			assert.Equal(t, tt.want, got)
 		})
+
 	}
+
+}
+
+func Test_storage_Retention(t *testing.T) {
+
+	test := struct {
+		name    string
+		storage storage
+		metric  string
+		labels  []Label
+		start   int64
+		end     int64
+		want    time.Duration
+		wantErr bool
+	}{
+
+		name: "GetRetention test",
+		storage: func() storage {
+
+			return storage{
+				retention: time.Hour * 12,
+			}
+		}(),
+		want: time.Hour * 12,
+	}
+
+	assert.Equal(t, test.want, test.storage.GetRetention())
 }


### PR DESCRIPTION
Hi @nakabonne, it is a really great and useful repository, thanks for developing. As a feature I would like to be able to collect configured and default values of the database and I thought that I could create a pull request. If you think that it is suitable for the convention of the repository. I would like to add other get methods of (partition duration, walbuffer) and so on.


Kind Regards