### PR TITLE
Move int64 to beginning of struct to ensure alignment (fixes 32-bit ARM crash)

### DIFF
--- a/memory_partition.go
+++ b/memory_partition.go
@@ -11,13 +11,14 @@ import (
 // A memoryPartition implements a partition to store data points on heap.
 // It offers a goroutine safe capabilities.
 type memoryPartition struct {
-	// A hash map from metric name to memoryMetric.
-	metrics sync.Map
 	// The number of data points
 	numPoints int64
 	// minT is immutable.
 	minT int64
 	maxT int64
+
+	// A hash map from metric name to memoryMetric.
+	metrics sync.Map
 
 	// Write ahead log.
 	wal wal


### PR DESCRIPTION
This change reorders the fields in `memoryPartition` to ensure safe access on some architectures.

In particular, 32-bit operating systems running on ARM processors (common with Raspberry Pi) will encounter errors.

You can reproduce the crash by running the tests on a `armv7l` machine:

```
pi@stream:~/tstorage$ go test
--- FAIL: Test_memoryPartition_InsertRows (0.00s)
panic: unaligned 64-bit atomic operation [recovered]
        panic: unaligned 64-bit atomic operation

goroutine 36 [running]:
testing.tRunner.func1.2({0x205e80, 0x278fb4})
        /usr/local/go/src/testing/testing.go:1526 +0x27c
testing.tRunner.func1()
        /usr/local/go/src/testing/testing.go:1529 +0x42c
panic({0x205e80, 0x278fb4})
        /usr/local/go/src/runtime/panic.go:884 +0x218
runtime/internal/atomic.panicUnaligned()
        /usr/local/go/src/runtime/internal/atomic/unaligned.go:8 +0x24
runtime/internal/atomic.Store64(0x112e42c, 0x2)
        /usr/local/go/src/runtime/internal/atomic/atomic_arm.s:291 +0x14
github.com/nakabonne/tstorage.(*memoryPartition).insertRows.func1()
        /home/pi/tstorage/memory_partition.go:74 +0xd4
sync.(*Once).doSlow(0x112e454, 0x10286ac)
        /usr/local/go/src/sync/once.go:74 +0xb8
sync.(*Once).Do(0x112e454, 0x10286ac)
        /usr/local/go/src/sync/once.go:65 +0x40
github.com/nakabonne/tstorage.(*memoryPartition).insertRows(0x112e410, {0x1100360, 0x1, 0x1})
        /home/pi/tstorage/memory_partition.go:66 +0xb0
github.com/nakabonne/tstorage.Test_memoryPartition_InsertRows.func1()
        /home/pi/tstorage/memory_partition_test.go:40 +0xb8
github.com/nakabonne/tstorage.Test_memoryPartition_InsertRows(0x1107590)
        /home/pi/tstorage/memory_partition_test.go:44 +0x58
testing.tRunner(0x1107590, 0x2457fc)
        /usr/local/go/src/testing/testing.go:1576 +0x118
created by testing.(*T).Run
        /usr/local/go/src/testing/testing.go:1629 +0x43c
exit status 2
FAIL    github.com/nakabonne/tstorage   0.017s
```

This issue has been identified and addressed in other modules: https://github.com/owncloud/ocis/pull/1888

The Golang project documents this at https://golang.org/pkg/sync/atomic/#pkg-note-BUG mentioning it is the "caller's responsibility to arrange for 64-bit alignment of 64-bit words accessed atomically" and "The first word in (...) an allocated struct (...) can be relied upon to be 64-bit aligned"